### PR TITLE
[CIRCLE-14970] Add "exclude" parameter for skipping certain directories

### DIFF
--- a/shellcheck.yml
+++ b/shellcheck.yml
@@ -11,6 +11,10 @@ jobs:
       Add this job to any workflow to automatically check any shell scripts
       in your repository.
     parameters:
+      exclude:
+        type: string
+        default: ""
+        description: This file pattern is used to compare paths to exclude when searching for files.
       path:
         type: string
         default: .
@@ -24,7 +28,7 @@ jobs:
       - checkout
       - run:
           name: Check Scripts
-          command: find '<< parameters.path >>' -type f -name '<< parameters.pattern >>' | tee /dev/tty | xargs shellcheck --external-sources
+          command: find '<< parameters.path >>' -not -path '<< parameters.exclude >>' -type f -name '<< parameters.pattern >>' | tee /dev/tty | xargs shellcheck --external-sources
 
 executors:
   shellcheck:


### PR DESCRIPTION
I've tested this command against the CLI:

```
# skip anything in vendor:
$ find . -type f -not -path './vendor/*' -name '*.sh'
./.circleci/brew-deploy.sh
./.circleci/deploy-gh-pages.sh
./.circleci/generate-docs.sh
./install.sh
```

```
# show results for default value of blank string:
$ find . -type f -not -path '' -name '*.sh'
./vendor/golang.org/x/sys/unix/mkerrors.sh
./vendor/golang.org/x/sys/unix/mkall.sh
./vendor/google.golang.org/appengine/internal/regen.sh
./vendor/github.com/onsi/ginkgo/before_pr.sh
./.circleci/brew-deploy.sh
./.circleci/deploy-gh-pages.sh
./.circleci/generate-docs.sh
./install.sh
```
