### PR TITLE
Clarify docs and add example for exclude path

### DIFF
--- a/shellcheck.yml
+++ b/shellcheck.yml
@@ -14,12 +14,28 @@ examples:
       version: 2.1
 
       orbs:
-        shellcheck: circleci/shellcheck@1.2.0
+        shellcheck: circleci/shellcheck@1.0.0
 
       workflows:
         shellcheck:
           jobs:
             - shellcheck/check
+
+  exclude-path:
+    description: |
+      Exclude subdirectory 'foo' and its contents
+
+    usage:
+      version: 2.1
+
+      orbs:
+        shellcheck: circleci/shellcheck@1.0.0
+
+      workflows:
+        shellcheck:
+          jobs:
+            - shellcheck/check:
+                exclude: './foo/*'
 
   custom-executor:
     description: |
@@ -29,7 +45,7 @@ examples:
       version: 2.1
 
       orbs:
-        shellcheck: circleci/shellcheck@1.2.0
+        shellcheck: circleci/shellcheck@1.0.0
 
       executors:
         my-custom-executor:
@@ -54,8 +70,9 @@ jobs:
         type: string
         default: ""
         description: |
-          This file pattern is used to compare paths to exclude when searching
-          for files.
+          This file pattern (as passed to `find -not -path`) is used to select
+          a path to exclude when searching for files. Currently, this is
+          limited to a single pattern.
       path:
         type: string
         default: .


### PR DESCRIPTION
Clarify the docs a bit about exclude paths, and add an example.

Also standardize on 1.0.0 as version in example (which seems to be the convention)

That said, I'm thinking it might make sense to either switch to `-not -regex`, or at least allow that as an option, or else just have an open-ended `-not` expression where one can specify
` \( -name "./foo/*" -o -name "./bar/" \)`, say?