### PR TITLE
Switch to shellcheck-alpine

### DIFF
--- a/shellcheck.yml
+++ b/shellcheck.yml
@@ -85,4 +85,4 @@ executors:
     description: |
       This is a docker image that contains the `shellcheck` binary.
     docker:
-      - image: koalaman/shellcheck:v0.6.0
+      - image: koalaman/shellcheck-alpine:v0.6.0


### PR DESCRIPTION
Fixes #6 

The regular shellcheck docker image doesn't have a Linux runtime.