### PR TITLE
update example to match the latest release

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -22,7 +22,7 @@ examples:
       version: 2.1
 
       orbs:
-        shellcheck: circleci/shellcheck@1.0.0
+        shellcheck: circleci/shellcheck@1.3.8
 
       workflows:
         shellcheck:
@@ -37,7 +37,7 @@ examples:
       version: 2.1
 
       orbs:
-        shellcheck: circleci/shellcheck@1.0.0
+        shellcheck: circleci/shellcheck@1.3.8
 
       workflows:
         shellcheck:
@@ -53,7 +53,7 @@ examples:
       version: 2.1
 
       orbs:
-        shellcheck: circleci/shellcheck@1.0.0
+        shellcheck: circleci/shellcheck@1.3.8
 
       executors:
         my-custom-executor:

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -22,7 +22,7 @@ examples:
       version: 2.1
 
       orbs:
-        shellcheck: circleci/shellcheck@1.3.8
+        shellcheck: circleci/shellcheck@x.y.z
 
       workflows:
         shellcheck:
@@ -37,7 +37,7 @@ examples:
       version: 2.1
 
       orbs:
-        shellcheck: circleci/shellcheck@1.3.8
+        shellcheck: circleci/shellcheck@x.y.z
 
       workflows:
         shellcheck:
@@ -53,7 +53,7 @@ examples:
       version: 2.1
 
       orbs:
-        shellcheck: circleci/shellcheck@1.3.8
+        shellcheck: circleci/shellcheck@x.y.z
 
       executors:
         my-custom-executor:


### PR DESCRIPTION
The latest release is 1.3.8 however the examples use 1.0.0, this PR update the examples to use the latest release, to avoid confusion.

