### PR TITLE
Add "output" parameter for test output retention

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -90,6 +90,13 @@ jobs:
         default: "*.sh"
         description: |
           The file pattern as passed to `find` to locate shell scripts.
+      output:
+        type: string
+        default: /dev/tty
+        description: |
+          The destination of the test reports. By default they are sent only
+          to the tty stdout, but the path to a file can be set here to allow
+          them to be saved as job artifacts.
       executor:
         type: executor
         default: shellcheck
@@ -102,5 +109,5 @@ jobs:
           name: Check Scripts
           command: >
             find '<< parameters.path >>' -not -path '<< parameters.exclude >>'
-            -type f -name '<< parameters.pattern >>' | tee /dev/tty
-            | xargs shellcheck --external-sources
+            -type f -name '<< parameters.pattern >>' | tee -a
+            '<< parameters.output >>' | xargs shellcheck --external-sources

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -92,11 +92,10 @@ jobs:
           The file pattern as passed to `find` to locate shell scripts.
       output:
         type: string
-        default: /dev/tty
+        default: shellcheck.log
         description: |
-          The destination of the test reports. By default they are sent only
-          to the tty stdout, but the path to a file can be set here to allow
-          them to be saved as job artifacts.
+          The filename of the shellcheck output, which is automatically saved
+          as a job artifact.
       executor:
         type: executor
         default: shellcheck
@@ -109,5 +108,8 @@ jobs:
           name: Check Scripts
           command: >
             find '<< parameters.path >>' -not -path '<< parameters.exclude >>'
-            -type f -name '<< parameters.pattern >>' | tee -a
-            '<< parameters.output >>' | xargs shellcheck --external-sources
+            -type f -name '<< parameters.pattern >>' | xargs shellcheck --external-sources | tee -a
+            '<< parameters.output >>'
+      - store_artifacts:
+          path: '<< parameters.output >>'
+          destination: shellcheck


### PR DESCRIPTION
When I saw this orb I instantly thought "Yes! I knew digging around in this orb documentation like a drunken mole was going to serve a purpose!" which, to my chagrin, was brought to an untimely end when I reviewed the available parameters and saw no mention of a log file option so I could harvest them as artifacts within the workflow. Hopefully this PR will return me to "chair-dancing drunken mole" status and prove beneficial to other users of this orb as well. :hamster: 

Honestly I'm just getting my feet wet with your service so I hope I didn't commit any thoroughly embarrassing gaffes in constructing this addition to the config file, but if I did, just let me know and I'll gladly go back and rectify them. I feel I've benefited greatly from your generosity in opening the platform gratis to FOSS projects and am glad I found even a small way to give something back.

Cheers. :clinking_glasses: 