### PR TITLE
Update default shellcheck version from 0.6.0 to 0.7.0

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -11,7 +11,7 @@ executors:
     description: |
       This is a docker image that contains the `shellcheck` binary.
     docker:
-      - image: koalaman/shellcheck-alpine:v0.6.0
+      - image: koalaman/shellcheck-alpine:v0.7.0
 
 examples:
   shellcheck-workflow:


### PR DESCRIPTION
shellcheck v0.7.0 contains [many improvements and bug fixes](https://github.com/koalaman/shellcheck/compare/v0.6.0...v0.7.0) and doesn't have critical issues as far as I know.

I've tested this change works at [my demo branch](https://github.com/vzvu3k6k/Spoon-Knife/pull/1).