### PR TITLE
Add an example showing how to install git and ssh

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -66,6 +66,29 @@ examples:
             - shellcheck/check:
                 executor: my-custom-executor
 
+  add-git-and-ssh:
+    description: |
+      Pre-install git and ssh, for example to run tests against a git tag.
+
+    usage:
+      version: 2.1
+
+      orbs:
+        shellcheck: circleci/shellcheck@x.y.z
+
+      workflows:
+        shellcheck:
+          jobs:
+            - shellcheck/check:
+                pre-steps:
+                  - run:
+                      name: "Install git and SSH client"
+                      command: |
+                        apk add \
+                            --update-cache \
+                            --no-progress \
+                            git \
+                            openssh-client
 jobs:
   check:
     description: |


### PR DESCRIPTION
As the default executor used by the shellcheck orb is lacking git
and ssh, CircleCI will fall back to its own implementation.

While this works fine for many cases, there are a few for which
this does not work. One of those is execution of CI on git tags.

A workaround which works well for us is to pre-install the
[required tools](https://circleci.com/docs/2.0/custom-images/#required-tools-for-primary-containers)
in those cases.