### PR TITLE
adding multiple templates for github issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,27 @@
+---
+name: "Bug report"
+about: Create a report to help improve the project
+labels: bug
+
+---
+
+### Orb version
+
+<!---
+  e.g., 1.0.0
+  find this information in your config.yml file;
+  if the version is @volatile, check the top of your CircleCI-generated,
+  expanded configuration file, viewable from the "Configuration" tab of
+  any job page, for the orb's specific semantic version number
+-->
+
+### What happened
+
+<!---
+  please include any relevant links to CircleCI workflows or jobs
+  where you saw this behavior
+-->
+
+### Expected behavior
+
+<!--- what should happen, ideally? -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,18 @@
+---
+name: "Feature request"
+about: Suggest an idea that will improve the project
+labels: enhancement
+
+---
+
+## What would you like to be added
+
+<!---
+  please describe the idea you have and the problem you are trying to solve
+-->
+
+## Why is this needed
+
+<!---
+  please explain why is this feature needed and how it improves the project
+-->


### PR DESCRIPTION
This PR adds GitHub issue templates according to [the latest Github guidelines for multiple issue templates](https://help.github.com/en/articles/about-issue-and-pull-request-templates).

Added two templates:
- bug report template with `bug` label
- feature request template with `enhancement ` label