### PR TITLE
[semver:patch] Pass format through to shellcheck

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,11 +56,16 @@ workflows:
             - shellcheck/install
           path: src/tests
 
-      - orb-tools/publish-dev:
-          orb-name: circleci/shellcheck
+      - hold-for-dev-publish:
+          type: approval
           requires:
+            - orb-tools/lint
             - orb-tools/pack
             - bats/run
+
+      - orb-tools/publish-dev:
+          orb-name: circleci/shellcheck
+          requires: [ hold-for-dev-publish ]
 
       - orb-tools/trigger-integration-tests-workflow:
           name: trigger-integration-dev

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,11 +66,13 @@ workflows:
       - orb-tools/publish-dev:
           orb-name: circleci/shellcheck
           requires: [ hold-for-dev-publish ]
+          context: orb-publishing
 
       - orb-tools/trigger-integration-tests-workflow:
           name: trigger-integration-dev
           requires:
             - orb-tools/publish-dev
+          context: orb-publishing
 
   integration-tests_prod-release:
     when: << pipeline.parameters.run-integration-tests >>

--- a/src/commands/check.yml
+++ b/src/commands/check.yml
@@ -46,6 +46,7 @@ steps:
         SC_PARAM_EXCLUDE: <<parameters.exclude>>
         SC_PARAM_DIR: <<parameters.dir>>
         SC_PARAM_SEVERITY: <<parameters.severity>>
+        SC_PARAM_FORMAT: <<parameters.format>>
         SC_PARAM_OUTPUT: <<parameters.output>>
         SC_PARAM_SHELL: <<parameters.shell>>
         SC_PARAM_PATTERN: <<parameters.pattern>>

--- a/src/scripts/check.sh
+++ b/src/scripts/check.sh
@@ -21,8 +21,7 @@ Run_ShellCheck() {
     set +e
     while IFS= read -r script
     do
-        # shellcheck disable=SC2086
-        shellcheck $SHELLCHECK_EXCLUDE_PARAM --shell=$SC_PARAM_SHELL --severity=$SC_PARAM_SEVERITY --format=$SC_PARAM_FORMAT "$script" >> $SC_PARAM_OUTPUT
+        shellcheck "$SHELLCHECK_EXCLUDE_PARAM" --shell="$SC_PARAM_SHELL" --severity="$SC_PARAM_SEVERITY" --format="$SC_PARAM_FORMAT" "$script" >> "$SC_PARAM_OUTPUT"
     done < tmp
     set -eo pipefail
 }

--- a/src/scripts/check.sh
+++ b/src/scripts/check.sh
@@ -22,7 +22,7 @@ Run_ShellCheck() {
     while IFS= read -r script
     do
         # shellcheck disable=SC2086
-        shellcheck $SHELLCHECK_EXCLUDE_PARAM --shell=$SC_PARAM_SHELL --severity=$SC_PARAM_SEVERITY "$script" >> $SC_PARAM_OUTPUT
+        shellcheck $SHELLCHECK_EXCLUDE_PARAM --shell=$SC_PARAM_SHELL --severity=$SC_PARAM_SEVERITY --format=$SC_PARAM_FORMAT "$script" >> $SC_PARAM_OUTPUT
     done < tmp
     set -eo pipefail
 }

--- a/src/tests/check-test.bats
+++ b/src/tests/check-test.bats
@@ -26,6 +26,7 @@ teardown() {
     export SC_PARAM_DIR="src/tests/test_data"
     export SC_PARAM_SEVERITY="style"
     export SC_PARAM_EXCLUDE="SC2148,SC2038,SC2059"
+    export SC_PARAM_FORMAT="tty"
     Set_SHELLCHECK_EXCLUDE_PARAM
     SC_PARAM_PATTERN="*.fake"
     Run_ShellCheck
@@ -37,6 +38,7 @@ teardown() {
 @test "3: Shellcheck test - Fail on error" {
     export SC_PARAM_DIR="src/tests/test_data"
     export SC_PARAM_SEVERITY="style"
+    export SC_PARAM_FORMAT="tty"
     Set_SHELLCHECK_EXCLUDE_PARAM
     Run_ShellCheck
     run Catch_SC_Errors
@@ -48,6 +50,7 @@ teardown() {
     export SC_PARAM_DIR="src/tests/test_data"
     export SC_PARAM_SEVERITY="style"
     export SC_PARAM_EXCLUDE="SC2006,SC2116,SC2034"
+    export SC_PARAM_FORMAT="tty"
     Set_SHELLCHECK_EXCLUDE_PARAM
     Run_ShellCheck
     run Catch_SC_Errors


### PR DESCRIPTION
It looks like the `format` parameter was being dropped. This should pass it through to `shellcheck` as expected.

I've also taken the liberty of un-disabling `SC2086` for this line, since it looked to me like these variables really should be quoted. I might be missing a reason we wanted them to be un-quoted, though.