### PR TITLE
[semver:minor] Don't pass --shell when not given

### DIFF
--- a/src/commands/check.yml
+++ b/src/commands/check.yml
@@ -37,7 +37,7 @@ parameters:
       as a job artifact
   shell:
     type: string
-    default: "bash"
+    default: ""
     description: Shell language to check against.
   pattern:
     type: string

--- a/src/scripts/check.sh
+++ b/src/scripts/check.sh
@@ -15,6 +15,14 @@ Set_SHELLCHECK_EXTERNAL_SOURCES_PARAM() {
     fi
 }
 
+Set_SHELLCHECK_SHELL_PARAM() {
+    if [ -n "$SC_PARAM_SHELL" ]; then
+        SHELLCHECK_SHELL_PARAM="--shell=$SC_PARAM_SHELL "
+    else
+        SHELLCHECK_SHELL_PARAM=""
+    fi
+}
+
 Check_for_shellcheck() {
     if ! command -v shellcheck &> /dev/null
     then
@@ -29,7 +37,7 @@ Run_ShellCheck() {
     set +e
     while IFS= read -r script
     do
-        shellcheck "$SHELLCHECK_EXCLUDE_PARAM" "$SHELLCHECK_EXTERNAL_SOURCES" --shell="$SC_PARAM_SHELL" --severity="$SC_PARAM_SEVERITY" --format="$SC_PARAM_FORMAT" "$script" >> "$SC_PARAM_OUTPUT"
+        shellcheck "$SHELLCHECK_EXCLUDE_PARAM" "$SHELLCHECK_EXTERNAL_SOURCES" "$SHELLCHECK_SHELL_PARAM" --severity="$SC_PARAM_SEVERITY" --format="$SC_PARAM_FORMAT" "$script" >> "$SC_PARAM_OUTPUT"
     done < tmp
     set -eo pipefail
 }
@@ -48,6 +56,7 @@ SC_Main() {
     Check_for_shellcheck
     Set_SHELLCHECK_EXCLUDE_PARAM
     Set_SHELLCHECK_EXTERNAL_SOURCES_PARAM
+    Set_SHELLCHECK_SHELL_PARAM
     Run_ShellCheck
     Catch_SC_Errors
     rm tmp


### PR DESCRIPTION
By default, shellcheck autodetects the shell from the shebang. This default was preventing that.