### PR TITLE
[semver:minor] Also make `shell` optional in the job

### DIFF
--- a/src/jobs/check.yml
+++ b/src/jobs/check.yml
@@ -48,7 +48,7 @@ parameters:
       If a custom execution environment is needed, use the "install" command in a custom job.
   shell:
     type: string
-    default: "bash"
+    default: ""
     description: Shell language to check against.
   pattern:
     type: string


### PR DESCRIPTION
Ah, shoot. In #30, I didn't notice that I was only changing the default for the command; if you use the job, you still get `bash` as the default. This should fix that. Sorry for making this a new release. 😞 