### PR TITLE
[semver:patch] Do not use ./tmp as filename for sc input files

### DIFF
--- a/src/scripts/check.sh
+++ b/src/scripts/check.sh
@@ -39,7 +39,7 @@ Run_ShellCheck() {
     while IFS= read -r script
     do
         shellcheck "$SHELLCHECK_EXCLUDE_PARAM" "$SHELLCHECK_EXTERNAL_SOURCES" "$SHELLCHECK_SHELL_PARAM" --severity="$SC_PARAM_SEVERITY" --format="$SC_PARAM_FORMAT" "$script" >> "$SC_PARAM_OUTPUT"
-    done < "{$SC_INPUT_FILES}"
+    done < "${SC_INPUT_FILES}"
     set -eo pipefail
 }
 

--- a/src/scripts/check.sh
+++ b/src/scripts/check.sh
@@ -33,13 +33,13 @@ Check_for_shellcheck() {
 
 Run_ShellCheck() {
     SC_PARAM_PATTERN="${SC_PARAM_PATTERN:-"*.sh"}"
-    sc_input_files=/tmp/sc-input-files
-    find "$SC_PARAM_DIR" ! -name "$(printf "*\n*")" -name "$SC_PARAM_PATTERN" > "$sc_input_files"
+    SC_INPUT_FILES=/tmp/sc-input-files
+    find "$SC_PARAM_DIR" ! -name "$(printf "*\n*")" -name "$SC_PARAM_PATTERN" > "${SC_INPUT_FILES}"
     set +e
     while IFS= read -r script
     do
         shellcheck "$SHELLCHECK_EXCLUDE_PARAM" "$SHELLCHECK_EXTERNAL_SOURCES" "$SHELLCHECK_SHELL_PARAM" --severity="$SC_PARAM_SEVERITY" --format="$SC_PARAM_FORMAT" "$script" >> "$SC_PARAM_OUTPUT"
-    done < "$sc_input_files"
+    done < "{$SC_INPUT_FILES}"
     set -eo pipefail
 }
 

--- a/src/scripts/check.sh
+++ b/src/scripts/check.sh
@@ -33,12 +33,13 @@ Check_for_shellcheck() {
 
 Run_ShellCheck() {
     SC_PARAM_PATTERN="${SC_PARAM_PATTERN:-"*.sh"}"
-    find "$SC_PARAM_DIR" ! -name "$(printf "*\n*")" -name "$SC_PARAM_PATTERN" > tmp
+    sc_input_files=/tmp/sc-input-files
+    find "$SC_PARAM_DIR" ! -name "$(printf "*\n*")" -name "$SC_PARAM_PATTERN" > "$sc_input_files"
     set +e
     while IFS= read -r script
     do
         shellcheck "$SHELLCHECK_EXCLUDE_PARAM" "$SHELLCHECK_EXTERNAL_SOURCES" "$SHELLCHECK_SHELL_PARAM" --severity="$SC_PARAM_SEVERITY" --format="$SC_PARAM_FORMAT" "$script" >> "$SC_PARAM_OUTPUT"
-    done < tmp
+    done < "$sc_input_files"
     set -eo pipefail
 }
 
@@ -59,7 +60,7 @@ SC_Main() {
     Set_SHELLCHECK_SHELL_PARAM
     Run_ShellCheck
     Catch_SC_Errors
-    rm tmp
+    rm /tmp/sc-input-files
 }
 
 

--- a/src/tests/check-test.bats
+++ b/src/tests/check-test.bats
@@ -18,7 +18,7 @@ teardown() {
     Set_SHELLCHECK_EXCLUDE_PARAM
     Run_ShellCheck
     # Test that 2 scripts were found
-    [ $(wc -l /tmp/sc-inputs-files | awk '{print $1}') == 2 ]
+    [ $(wc -l /tmp/sc-input-files | awk '{print $1}') == 2 ]
 }
 
 # Esure Shellcheck is able to find files with custom patterns

--- a/src/tests/check-test.bats
+++ b/src/tests/check-test.bats
@@ -18,7 +18,7 @@ teardown() {
     Set_SHELLCHECK_EXCLUDE_PARAM
     Run_ShellCheck
     # Test that 2 scripts were found
-    [ $(wc -l tmp | awk '{print $1}') == 2 ]
+    [ $(wc -l /tmp/sc-inputs-files | awk '{print $1}') == 2 ]
 }
 
 # Esure Shellcheck is able to find files with custom patterns
@@ -31,7 +31,7 @@ teardown() {
     SC_PARAM_PATTERN="*.fake"
     Run_ShellCheck
     # Test that 1 fake script was found
-    [ $(wc -l tmp | awk '{print $1}') == 1 ]
+    [ $(wc -l /tmp/sc-input-files | awk '{print $1}') == 1 ]
 }
 
 # Esure Shellcheck command provides a failure if errors are found


### PR DESCRIPTION
Please do not use filename "tmp" that collects all shellcheck input files. Doing so causes the shellcheck orb to fail when run against Ruby-on-Rails projects that contain a ./tmp directory. 