### PR TITLE
Fix `external_sources` parameter [semver:patch]

### DIFF
--- a/src/scripts/check.sh
+++ b/src/scripts/check.sh
@@ -7,7 +7,7 @@ Set_SHELLCHECK_EXCLUDE_PARAM() {
 }
 
 Set_SHELLCHECK_EXTERNAL_SOURCES_PARAM() {
-    if [ "$SC_PARAM_EXTERNAL_SOURCES" == "true" ]; then
+    if [ "$SC_PARAM_EXTERNAL_SOURCES" == "1" ]; then
         SHELLCHECK_EXTERNAL_SOURCES="--external-sources"
     else
         SHELLCHECK_EXTERNAL_SOURCES=""


### PR DESCRIPTION
This PR fixes the parameter check so the `external_sources` is passed to shellcheck via the `--external-sources` flag.

Boolean parameters are converted to their int representations (`true` => `1`, `false` => `0`) when passed via the environment (see #38 for detailed bug description).

Fixes #38