### PR TITLE
Remove trailing space from parameters [semver:patch]

### DIFF
--- a/src/scripts/check.sh
+++ b/src/scripts/check.sh
@@ -1,6 +1,6 @@
 Set_SHELLCHECK_EXCLUDE_PARAM() {
     if [ -n "$SC_PARAM_EXCLUDE" ]; then
-        SHELLCHECK_EXCLUDE_PARAM="--exclude=$SC_PARAM_EXCLUDE "
+        SHELLCHECK_EXCLUDE_PARAM="--exclude=$SC_PARAM_EXCLUDE"
     else
         SHELLCHECK_EXCLUDE_PARAM=""
     fi
@@ -16,7 +16,7 @@ Set_SHELLCHECK_EXTERNAL_SOURCES_PARAM() {
 
 Set_SHELLCHECK_SHELL_PARAM() {
     if [ -n "$SC_PARAM_SHELL" ]; then
-        SHELLCHECK_SHELL_PARAM="--shell=$SC_PARAM_SHELL "
+        SHELLCHECK_SHELL_PARAM="--shell=$SC_PARAM_SHELL"
     else
         SHELLCHECK_SHELL_PARAM=""
     fi


### PR DESCRIPTION
This PR removes the trailing spaces which shellcheck can't parse correctly (for detailed bug description, see #37).
There was no open issue for the `--shell` parameter, and I don't know if it causes problems since I haven't tested this parameter, but I don't think there is a reason for this space whatsoever, so I decided to remove it as well.

Thanks in advance for your feedback!

Fixes #37