### PR TITLE
Update custom_shellcheck_job.yml example

### DIFF
--- a/src/examples/custom_shellcheck_job.yml
+++ b/src/examples/custom_shellcheck_job.yml
@@ -21,7 +21,5 @@ usage:
   workflows:
     my_workflow:
       jobs:
-        - shellcheck/check:
-            dir: ./myScripts
-            exclude: "SC2148"
+        - my_job
 


### PR DESCRIPTION
It looks like the workflow definition was copy-pasta'd from the other example, and it doesn't call our custom job.