### PR TITLE
fix: exit 1 when shellcheck is not installed

### DIFF
--- a/src/scripts/check.sh
+++ b/src/scripts/check.sh
@@ -21,7 +21,7 @@ Check_For_ShellCheck() {
     if ! command -v shellcheck &> /dev/null
     then
         echo "Shellcheck not installed"
-        exit
+        exit 1
     fi
 }
 


### PR DESCRIPTION
Running this Orb with a custom image that doesn't have shellcheck installed will result in the workflow returning "Shellcheck not installed" with a _success_ exit code. This PR changes the exit status to 1 so that the job will fail if shellcheck is not installed (and therefore not ran).