### PR TITLE
[semver:minor] Add circleci ip range options

### DIFF
--- a/src/jobs/check.yml
+++ b/src/jobs/check.yml
@@ -6,6 +6,8 @@ description: |
 docker:
   - image: cimg/base:<<parameters.image-tag>>
 
+circleci_ip_ranges: << parameters.circleci_ip_ranges >>
+
 parameters:
   exclude:
     description: >
@@ -60,6 +62,11 @@ parameters:
     type: string
     default: ""
     description: The file pattern to search for. By default will search for "*.sh"
+  circleci_ip_ranges:
+    type: boolean
+    default: false
+    description: |
+      The IP ranges feature enables users to restrict network access to CircleCI jobs by allowing only requests originating from specified IP ranges. For detailed documentation on "circleci_ip_ranges", you can refer to the official CircleCI documentation: [IP Ranges](https://circleci.com/docs/ip-ranges/)
 
 steps:
   - checkout


### PR DESCRIPTION
## Changes

Customer reported that when they have their GitHub managed allowed IP enabled they can not checkout using the orb tools.  To mitigate this issue I added the `circleci_ip_ranges` options.

> [Managing allowed IP addresses for your organization](https://docs.github.com/en/enterprise-cloud@latest/organizations/keeping-your-organization-secure/managing-security-settings-for-your-organization/managing-allowed-ip-addresses-for-your-organization): You can restrict access to your organization's private assets by configuring a list of IP addresses that are allowed to connect.

## Additional note

I thought of creating an executor that enables this but it looks like `circleci_ip_ranges` are not supported. There fore I gave up on creating an executor and created a pr to directly address this issue.

<img width="649" alt="Screenshot 2023-07-18 at 15 08 25" src="https://github.com/CircleCI-Public/orb-tools-orb/assets/6015450/2c20c2b9-40e8-41f9-996d-f234355e7c75">
