### PR TITLE
Add "resource_class" as a parameter to the "check" job

### DIFF
--- a/src/jobs/check.yml
+++ b/src/jobs/check.yml
@@ -6,6 +6,8 @@ description: |
 docker:
   - image: cimg/base:<<parameters.image-tag>>
 
+resource_class: << parameters.resource_class >>
+
 parameters:
   exclude:
     description: >
@@ -52,6 +54,11 @@ parameters:
       Shellcheck is included in the CircleCI authored `cimg/base` docker image (Feb 2022 onward), installed via the official Ubuntu packages.
       By default the most current stable release of this image will be used, but you may statically set the image tag with this parameter.
       https://circleci.com/developer/images/image/cimg/base
+  resource_class:
+    description: Configure the executor resource class
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: "medium"
   shell:
     type: string
     default: ""

--- a/src/jobs/check.yml
+++ b/src/jobs/check.yml
@@ -57,8 +57,8 @@ parameters:
   resource_class:
     description: Configure the executor resource class
     type: enum
-    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
-    default: "medium"
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+", "arm.medium", "arm.large", "arm.xlarge", "arm.2xlarge"]
+    default: "small"
   shell:
     type: string
     default: ""

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -4,8 +4,8 @@ if [[ $EUID == 0 ]]; then export SUDO=""; else # Check if we're root
 fi
 
 install_mac() {
-    curl -LJO "https://github.com/koalaman/shellcheck/releases/download/v${SC_INSTALL_VERSION}/shellcheck-v${SC_INSTALL_VERSION}.darwin.x86_64.tar.xz"
-    tar -xvf "shellcheck-v$SC_INSTALL_VERSION.darwin.x86_64.tar.xz"
+    curl -LJO "https://github.com/koalaman/shellcheck/releases/download/v${SC_INSTALL_VERSION}/shellcheck-v${SC_INSTALL_VERSION}.darwin.aarch64.tar.xz"
+    tar -xvf "shellcheck-v$SC_INSTALL_VERSION.darwin.aarch64.tar.xz"
     cd "shellcheck-v$SC_INSTALL_VERSION/" || false
     $SUDO cp shellcheck /usr/local/bin
 }


### PR DESCRIPTION
Allows the resource class for the executor to be specified.

Fixes #56