### PR TITLE
Allow Gen2 Docker resources

### DIFF
--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -1,0 +1,20 @@
+description: >
+  The circleci-cli Docker image, which includes the CircleCI CLI executable.
+
+parameters:
+  image:
+    type: string
+    default: "cimg/base:current"
+    description: |
+      Shellcheck is included in the CircleCI authored `cimg/base` docker image (Feb 2022 onward), installed via the official Ubuntu packages.
+      By default the most current stable release of this image will be used, but you may statically set the image with this parameter.
+      https://circleci.com/developer/images/image/cimg/base
+  resource_class:
+    description: Configure the executor resource class
+    type: enum
+    enum: ["small", "small.gen2", "medium", "medium.gen2", "medium+", "medium+.gen2", "large", "large.gen2", "xlarge", "xlarge.gen2", "2xlarge", "2xlarge.gen2", "2xlarge+", "2xlarge+.gen2", "arm.medium", "arm.large", "arm.xlarge", "arm.2xlarge", ]
+    default: "small"
+
+resource_class: << parameters.resource_class >>
+docker:
+  - image: << parameters.image >>

--- a/src/jobs/check.yml
+++ b/src/jobs/check.yml
@@ -19,6 +19,10 @@ parameters:
       Follow source statements even when the file is not specified as input.
     type: boolean
     default: false
+  executor: 
+    description: The executor to use for this job. By default, this will use the "default" executor provided by this orb.
+    type: executor
+    default: default
   dir:
     description: >
       Specify the root path containing the shell scripts. The directory will be recursively searched.
@@ -79,6 +83,8 @@ parameters:
     description: Enables jobs to go through a set of well-defined IP address ranges.
     type: boolean
     default: false
+
+executor: << parameters.executor >>
 
 circleci_ip_ranges: << parameters.circleci_ip_ranges >>
 

--- a/src/jobs/check.yml
+++ b/src/jobs/check.yml
@@ -52,25 +52,6 @@ parameters:
     description: |
       The filename of the shellcheck output, which is automatically saved
       as a job artifact
-  image-name:
-    type: string
-    default: "cimg/base"
-    description: |
-      Shellcheck is included in the CircleCI authored `cimg/base` docker image (Feb 2022 onward), installed via the official Ubuntu packages.
-      By default, "cimg/base" is used as the image, but you may specify a different base image with this parameter.
-      https://circleci.com/developer/images/image/cimg/base
-  image-tag:
-    type: string
-    default: "current"
-    description: |
-      Shellcheck is included in the CircleCI authored `cimg/base` docker image (Feb 2022 onward), installed via the official Ubuntu packages.
-      By default the most current stable release of this image will be used, but you may statically set the image tag with this parameter.
-      https://circleci.com/developer/images/image/cimg/base
-  resource_class:
-    description: Configure the executor resource class
-    type: enum
-    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+", "arm.medium", "arm.large", "arm.xlarge", "arm.2xlarge"]
-    default: "small"
   shell:
     type: string
     default: ""


### PR DESCRIPTION
Previously, there was no way to define a Gen2 Docker resource for the shellcheck orb. 

This takes out the `resource_class` and brings it to an executor, so you can change its settings, or bring your own (i.e. runner).